### PR TITLE
fix Scaladoc and add validation step to CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -19,5 +19,7 @@ jobs:
         with:
             docker_channel: stable
             docker_version: 20.10
+      - name: Validate Scaladoc
+        run: sbt doc
       - name: Run tests
         run: sbt test +IntegrationTest/test

--- a/src/main/scala/zio/cassandra/session/cql/package.scala
+++ b/src/main/scala/zio/cassandra/session/cql/package.scala
@@ -22,12 +22,12 @@ package object cql {
       * import unsafe._
       *
       * private val tableName = "my_table"
-      * def selectById(ids: Seq[Long) = cql"select id from ${lift(tableName)} where id in $ids".as[Int]
+      * def selectById(ids: Seq[Long]) = cql"select id from \${lift(tableName)} where id in \$ids".as[Int]
       * }}}
       * instead of
       * {{{
       * private val tableName = "my_table"
-      * def selectById(ids: Seq[Long) = (cqlConst"select id from $tableName" ++  cql"where id in $ids").as[Int]
+      * def selectById(ids: Seq[Long]) = (cqlConst"select id from \$tableName" ++  cql"where id in \$ids").as[Int]
       * }}}
       */
     def lift(value: Any): LiftedValue = LiftedValue(value)


### PR DESCRIPTION
Previous MR broke Scaladoc rendering because of two things:
1) Actual typo
2) bug (?) in Scaladoc renderer (https://github.com/scala/bug/issues/9815)
Escaped interpolation sign looks ok in documentation
<img width="774" alt="image" src="https://user-images.githubusercontent.com/28982711/181367334-11b100f1-0de1-4741-94ef-15b803f41961.png">
but still appears in Intellij docs
<img width="774" alt="image" src="https://user-images.githubusercontent.com/28982711/181367454-e2ad593d-dfe2-460d-9158-67b52e00ac0e.png">
I guess we'll need to create a bug report in Intellij IDEA one day

This MR fixes these two issues and also add a new `sbt doc` action to make sure that broken docs won't be merged anymore