### PR TITLE
Support execution of zio statements - add repeatZIO operator

### DIFF
--- a/src/it/scala/zio/cassandra/session/SessionSpec.scala
+++ b/src/it/scala/zio/cassandra/session/SessionSpec.scala
@@ -191,7 +191,7 @@ object SessionSpec extends ZIOCassandraSpec with ZIOCassandraSpecUtils {
                      s"""select id, p_nr, seq_nr from ${table} 
                    |where id = 'key' and p_nr = ? and seq_nr >= ? and seq_nr <= ?""".stripMargin
                    )
-        res     <- session.select(selectStatement(st)).runCount
+        res     <- session.repeatZIO(selectStatement(st)).runCount
       } yield assertTrue(records.size == res.toInt)
     }
   )

--- a/src/main/scala/zio/cassandra/session/Session.scala
+++ b/src/main/scala/zio/cassandra/session/Session.scala
@@ -104,7 +104,7 @@ object Session {
       }
     }
 
-    override def select(stmt: Task[Statement[_]]): Stream[Throwable, Row] =
+    override def select[R](stmt: ZIO[R, Throwable, Statement[_]]): ZStream[R, Throwable, Row] =
       select(stmt, continuous = true)
 
     override def select(stmt: Statement[_]): Stream[Throwable, Row] =


### PR DESCRIPTION
- [x] Added execution of zio statements
- [x] Added continuous stream of multipartition statements, e.g. select all records for composite keys or select multiple similar statements as a single stream