### PR TITLE
change default limit to 1 in selectFirst

### DIFF
--- a/src/main/scala/zio/cassandra/session/Session.scala
+++ b/src/main/scala/zio/cassandra/session/Session.scala
@@ -12,6 +12,7 @@ import zio.stream.{ Stream, ZStream }
 
 import scala.jdk.CollectionConverters.IterableHasAsScala
 import scala.jdk.OptionConverters.RichOptional
+import scala.language.existentials
 
 trait Session {
 
@@ -106,8 +107,11 @@ object Session {
     override def select(stmt: Statement[_]): Stream[Throwable, Row] =
       repeatZIO(ZIO.succeed(stmt), continuous = false)
 
-    override def selectFirst(stmt: Statement[_]): Task[Option[Row]] =
-      execute(stmt).map(rs => Option(rs.one()))
+    override def selectFirst(stmt: Statement[_]): Task[Option[Row]] = {
+      // setPageSize returns T <: Statement[T] for any T, but Scala can't figure it out without clues that will spoil library API
+      val single = stmt.setPageSize(1).asInstanceOf[Statement[_]]
+      execute(single).map(rs => Option(rs.one()))
+    }
 
     override def metrics: Option[Metrics] =
       underlying.getMetrics.toScala


### PR DESCRIPTION
### Way to reproduce
```scala
package zio.cassandra.session

import zio._
import zio.cassandra.session.cql.CqlStringContext
import zio.test.{ assertCompletes, Spec }

object QueryLimitsSpec extends ZIOCassandraSpec {

  val bar = "bar"

  override def spec: Spec[Session, Any] =
    suite("suite")(
      test("limit") {
        for {
          s <- ZIO.service[Session]
          _ <- s.execute("create table tests.foo(bar text, buzz int, primary key (bar, buzz))")
          _ <- ZIO.foreachDiscard(0 to 1000)(b => s.execute(cql"delete from tests.foo where bar = $bar and buzz = $b"))
          _ <- s.execute(cql"insert into tests.foo(bar, buzz) values ($bar, 1001)")
          _ <- s.selectFirst(cql"select * from tests.foo where bar = $bar and buzz < 1111")
        } yield assertCompletes
      }
    )

}
```
If you run the following code, you see a warning like this
```
2022-12-30 21:34:08.840+0200  warn [CqlRequestHandler] Query '[1 values] select * from tests.foo where bar = ? and buzz < 1111 [bar='bar']' generated server side warning(s): Read 1 live rows and 1001 tombstone cells for query SELECT * FROM tests.foo WHERE bar = bar AND buzz < 1111 LIMIT 5000; token -7911037993560119804 (see tombstone_warn_threshold)
```
Note `LIMIT 5000` part.
### The problem
Even though we are interested in only one item, Cassandra doesn't know that. In most cases it's not a big deal since when you select one item, you usually provide a full key. However, there are cases when you might want to select any value by clustering key or simply any value to check that the table is not empty. In these cases `selectFirst` might cause unnecessary actions in Cassandra.
### Solution
After adopting this PR, logs will look like this
```
2022-12-30 21:34:08.840+0200  warn [CqlRequestHandler] Query '[1 values] select * from tests.foo where bar = ? and buzz < 1111 [bar='bar']' generated server side warning(s): Read 1 live rows and 1001 tombstone cells for query SELECT * FROM tests.foo WHERE bar = bar AND buzz < 1111 LIMIT 1; token -7911037993560119804 (see tombstone_warn_threshold)
```
Also, it's still possible to override limit at query level if needed (`cql"select * from tests.foo where bar = $bar and buzz < 1111 limit 5"`), though it's hard to tell why anyone would ever need this