### PR TITLE
Minor optimizations v2

### DIFF
--- a/src/main/scala/zio/cassandra/session/Session.scala
+++ b/src/main/scala/zio/cassandra/session/Session.scala
@@ -121,7 +121,7 @@ object Session {
     ): ZChannel[R, Any, Any, Any, Throwable, Chunk[A], Any] =
       loop(io.flatMap(execute), fn, continuous, loop(io, fn, continuous))
 
-    private def loop[R, A, B](
+    private def loop[R, A](
       ch: ZIO[R, Throwable, AsyncResultSet],
       fn: Row => A,
       continuous: Boolean,
@@ -145,9 +145,9 @@ object Session {
     override def select(stmt: Statement[_]): Stream[Throwable, Row] =
       ZStream.fromChannel(loop(ZIO.succeed(stmt), identity, continuous = false))
 
-    override def repeatZIO[R, O](stmt: ZIO[R, Throwable, Statement[_]])(implicit
-      rds: Reads[O]
-    ): ZStream[R, Throwable, O] =
+    override def repeatZIO[R, A](stmt: ZIO[R, Throwable, Statement[_]])(implicit
+      rds: Reads[A]
+    ): ZStream[R, Throwable, A] =
       ZStream.fromChannel(loop(stmt, rds.read, continuous = true))
 
     override def selectFirst(stmt: Statement[_]): Task[Option[Row]] = {


### PR DESCRIPTION
+3-5% speed, -30-35% memory

```
sbt "bench/clean;bench/jmh:run -i 10 -r 10 -wi 10 -w 10 -f1 -t10 -prof gc"
[info] ZIOCassandraBench.repeatZChannel                                      1111  thrpt   10  13410.905 ±  289.636   ops/s
[info] ZIOCassandraBench.repeatZChannel:·gc.alloc.rate                       1111  thrpt   10    369.983 ±   46.878  MB/sec
[info] ZIOCassandraBench.repeatZIOPull                                       1111  thrpt   10  13042.193 ±  211.516   ops/s
[info] ZIOCassandraBench.repeatZIOPull:·gc.alloc.rate                        1111  thrpt   10    517.937 ±   64.685  MB/sec
```